### PR TITLE
improve: Reduce Genesys Cloud CX platform & Amazon Translate API calls, minor improvements

### DIFF
--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -103,21 +103,18 @@ let onMessage = (data) => {
 
             name = (purpose === 'customer') ? customerName : agentAlias
 
-            if (publish) {
+            if (publish && !messageIds.includes(messageId)) { // Make sure message is published only once
                 conversationsApi.getConversationsMessageMessage(data.eventBody.id, messageId)
                 .then((messageDetail => {
-                    // Make sure message is published only once
-                    if(!messageIds.includes(messageId)){
-                        // Ignore messages without text (e.g. Presence/Disconect Event)
-                        if (null != messageDetail.textBody) {
-                            messageIds.push(messageId);
+                    // Ignore messages without text (e.g. Presence/Disconect Event)
+                    if (null != messageDetail.textBody) {
+                        messageIds.push(messageId);
 
-                            // Wait for translate to finish before calling addChatMessage
-                            translate.translateText(messageDetail.textBody, genesysCloudLanguage, function(translatedData) {
-                                view.addChatMessage(name, translatedData.translated_text, purpose);
-                                translationData = translatedData;
-                            });
-                        }
+                        // Wait for translate to finish before calling addChatMessage
+                        translate.translateText(messageDetail.textBody, genesysCloudLanguage, function(translatedData) {
+                            view.addChatMessage(name, translatedData.translated_text, purpose);
+                            translationData = translatedData;
+                        });
                     }                    
                 }));          
             }            

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -152,7 +152,7 @@ function sendChat(){
     // Translate text to customer's local language
     translate.translateText(message, sourceLang, function(translatedData) {
         // Wait for translate to finish before calling sendMessage
-        sendMessage(translatedData.translated_text, currentConversationId, communicationId);
+        sendMessage(translatedData.translated_text, currentConversationId, communicationId, message);
     });
 
     document.getElementById('message-textarea').value = '';
@@ -161,7 +161,7 @@ function sendChat(){
 /**
  *  Send message to the customer
  */
-function sendMessage(message, conversationId, communicationId){
+function sendMessage(message, conversationId, communicationId, originalMessage = ''){
     console.log(message);
 
     if(messageType === 'chat') {
@@ -178,7 +178,13 @@ function sendMessage(message, conversationId, communicationId){
             {
                 'textBody': message
             }
-        )
+        ).then(result => {
+            if(originalMessage) {
+                // Do not double-translate message - show as agent entered it
+                messageIds.push(result.id);
+                view.addChatMessage(agentAlias, originalMessage, 'agent');
+            }
+        });
     }    
 }
 

--- a/docs/scripts/notifications-controller.js
+++ b/docs/scripts/notifications-controller.js
@@ -18,11 +18,10 @@ let subscriptionMap = {
 /**
  * Callback function for notications event-handling.
  * It will reference the subscriptionMap to determine what function to run
- * @param {Object} event 
+ * @param {Object} event
  */
-function onSocketMessage(event){
+function onSocketMessage(event) {
     let data = JSON.parse(event.data);
-
     subscriptionMap[data.topicName](data);
 }
 
@@ -31,7 +30,7 @@ export default {
      * Creation of the channel. If called multiple times,
      * the last one will be the active one.
      */
-    createChannel(){
+    createChannel() {
         return notificationsApi.postNotificationsChannels()
         .then(data => {
             console.log('---- Created Notifications Channel ----');
@@ -48,14 +47,14 @@ export default {
      * @param {String} topic PureCloud notification topic string
      * @param {Function} callback callback function to fire when the event occurs
      */
-    addSubscription(topic, callback){
-        let body = [{'id': topic}]
+    addSubscription(topic, callback) {
+        let body = [{ id: topic }];
 
         return notificationsApi.postNotificationsChannelSubscriptions(
                 channel.id, body)
-        .then((data) => {
+        .then(() => {
             subscriptionMap[topic] = callback;
             console.log(`Added subscription to ${topic}`);
         });
     }
-}
+};

--- a/docs/scripts/translate-service.js
+++ b/docs/scripts/translate-service.js
@@ -20,10 +20,10 @@ const languageCodeMapping = {
     'ja': 'ja',
     'zh-cn': 'zh',
     'zh-tw': 'zh-TW'
-}
+};
 
 export default {
-    translateText(text, language, callback){
+    translateText(text, language, callback) {
         let language_code = languageCodeMapping[language] ? 
                     languageCodeMapping[language] : language;
 
@@ -31,7 +31,7 @@ export default {
             raw_text: text,
             source_language: 'auto',
             target_language: language_code
-        }
+        };
 
         fetch(config.translateServiceURI,
             {
@@ -50,4 +50,4 @@ export default {
         })
         .catch(e => console.error(e));
     }
-}
+};

--- a/docs/scripts/view.js
+++ b/docs/scripts/view.js
@@ -1,7 +1,7 @@
 /**
  * This script is focused on the HTML / displaying of data to the page
  */
-function updateScroll(){
+function updateScroll() {
     let div = document.getElementById('agent-assist');
     div.scrollTop = div.scrollHeight;
 }
@@ -9,10 +9,10 @@ function updateScroll(){
 /**
  * Clear DIV of previous search results
  */
-function clearSearchResults(){
-    let searchContainer = document.getElementById("search-result-container");
+function clearSearchResults() {
+    let searchContainer = document.getElementById('search-result-container');
 
-    while (searchContainer.childNodes.length > 1) {  
+    while(searchContainer.childNodes.length > 1) {
         searchContainer.removeChild(searchContainer.lastChild);
     }
 }
@@ -20,14 +20,14 @@ function clearSearchResults(){
 /**
  * Convert the html content of the canned response to plain text
  */
-function htmlToPlain(rawHtml){
+function htmlToPlain(rawHtml) {
     let finalText = rawHtml;
     finalText = finalText.replace(/<\/div>/ig, '\n');
     finalText = finalText.replace(/<\/li>/ig, '\n');
     finalText = finalText.replace(/<li>/ig, '  *  ');
     finalText = finalText.replace(/<\/ul>/ig, '\n');
     finalText = finalText.replace(/<\/p>/ig, '\n');
-    finalText = finalText.replace(/<br\s*[\/]?>/gi, "\n");
+    finalText = finalText.replace(/<br\s*[/]?>/gi, '\n');
     finalText = finalText.replace(/<[^>]+>/ig, '');
 
     return finalText;
@@ -39,7 +39,7 @@ export default {
      * @param {String} sender sender name to be displayed
      * @param {String} message chat message to be displayed
      */
-    addChatMessage(sender, message, purpose){        
+    addChatMessage(sender, message, purpose) {
         let chatMsg = document.createElement('p');
         chatMsg.textContent = sender + ': ' + message;
 
@@ -53,22 +53,22 @@ export default {
 
     /**
      * Display list of libraries
-     * @param {String} libraryId 
-     * @param {String} libraryName 
+     * @param {String} libraryId
+     * @param {String} libraryName
      */
-    displayLibraries(libraryId, libraryName){
+    displayLibraries(libraryId, libraryName) {
         let libContainer = document.createElement('button');
         libContainer.textContent = libraryName;
         libContainer.id = 'library-' + libraryId;
         libContainer.className = 'collapsible';
         libContainer.addEventListener('click', function() {
             this.classList.toggle('active');
-            let content = this.nextElementSibling;	
-            if (content.style.display === 'block') {	
-                content.style.display = 'none';	
-            } else {	
-                content.style.display = 'block';	
-            }	
+            let content = this.nextElementSibling;
+            if(content.style.display === 'block') {
+                content.style.display = 'none';
+            } else {
+                content.style.display = 'block';
+            }
         });
         document.getElementById('libraries-container').appendChild(libContainer);
 
@@ -80,9 +80,9 @@ export default {
 
     /**
      * Display responses and group by libraries
-     * @param {Object} response 
+     * @param {Object} response
      */
-    displayResponses(response, doResponseSubstitution){
+    displayResponses(response, doResponseSubstitution) {
         let responseId = response.id;
 
         // Collapsible response name
@@ -92,12 +92,12 @@ export default {
         responseButton.className = 'collapsible';
         responseButton.addEventListener('click', function() {
             this.classList.toggle('active');
-            let content = this.nextElementSibling;	
-            if (content.style.display === 'block') {	
-                content.style.display = 'none';	
-            } else {	
-                content.style.display = 'block';	
-            }	
+            let content = this.nextElementSibling;
+            if(content.style.display === 'block') {
+                content.style.display = 'none';
+            } else {
+                content.style.display = 'block';
+            }
         });
         document.getElementById('responses-container-' + response.libraries[0].id).appendChild(responseButton);
 
@@ -109,7 +109,7 @@ export default {
         responseText.addEventListener('click', function() {
             let text = htmlToPlain(response.texts[0].content);
             doResponseSubstitution(text, responseId)
-            .then((finalText) => {
+            .then(finalText => {
                 document.getElementById('message-textarea').value = finalText;
             })
             .catch(e => console.error(e));
@@ -119,9 +119,9 @@ export default {
 
     /**
      * Displays all search results in a DIV
-     * @param {object} results 
+     * @param {object} results
      */
-    displaySearchResults(results, doResponseSubstitution){
+    displaySearchResults(results, doResponseSubstitution) {
         let responseId = results.id;
 
         // Collapsible response name
@@ -131,12 +131,12 @@ export default {
         responseButton.className = 'collapsible';
         responseButton.addEventListener('click', function() {
             this.classList.toggle('active');
-            let content = this.nextElementSibling;	
-            if (content.style.display === 'block') {	
-                content.style.display = 'none';	
-            } else {	
-                content.style.display = 'block';	
-            }	
+            let content = this.nextElementSibling;
+            if(content.style.display === 'block') {
+                content.style.display = 'none';
+            } else {
+                content.style.display = 'block';
+            }
         });
         document.getElementById('search-result-container').appendChild(responseButton);
 
@@ -148,7 +148,7 @@ export default {
         responseText.addEventListener('click', function() {
             let text = htmlToPlain(results.texts[0].content);
             doResponseSubstitution(text, responseId)
-            .then((finalText) => {
+            .then(finalText => {
                 document.getElementById('message-textarea').value = finalText;
             })
             .catch(e => console.error(e));
@@ -159,11 +159,11 @@ export default {
     /**
      * This toggles between showing Canned Responses or Search Results
      */
-    toggleDIVs(){
+    toggleDIVs() {
         let cannedDIV = document.getElementById('libraries-container');
         let searchDIV = document.getElementById('search-result-container');
 
-        if(cannedDIV.style.display === 'block'){
+        if(cannedDIV.style.display === 'block') {
             cannedDIV.style.display = 'none';
             searchDIV.style.display = 'block';
         } else {
@@ -172,7 +172,7 @@ export default {
         }
 
         // Clear DIV of previous search results
-        let searchContainer = document.getElementById("search-result-container");
+        let searchContainer = document.getElementById('search-result-container');
         if(searchContainer.children.length > 1) clearSearchResults();
     }
-}
+};


### PR DESCRIPTION
This PR includes:

- main.js/onMessage: do not call the platform API to fetch the message body if the message has already been published (displayed). 
- main.js/sendChat & sendMessage: do not double-translate the agent's message.
   - Previously, when a message was sent by the agent using the translation tool, it would not be displayed until received via the notification channel, and like all messages received via the channel, sent back through Amazon Translate. This resulted in two rounds of translation on sent messages, rather than just the one required for the customer's language. 
- main.js, notifications-controller.js, translate-service.js, view.js: linting and minor improvements e.g. typo fixes, addition of semicolons, and whitespace cleanup. 

Similar to #7, some improvements here were made only for messaging, as ACD web chat v1 and v2 are both deprecated and scheduled to be removed in 2025.